### PR TITLE
Parse string date example

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateTimeSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateTimeSchema.java
@@ -16,6 +16,9 @@
 
 package io.swagger.v3.oas.models.media;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -51,6 +54,9 @@ public class DateTimeSchema extends Schema<Date> {
             try {
                 if (value instanceof Date) {
                     return (Date) value;
+                } else if (value instanceof String) {
+                    TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse((String) value);
+                    return Date.from(Instant.from(ta));
                 }
             } catch (Exception e) {
             }


### PR DESCRIPTION
This PR adds simple parsing of strings to Date values in the `cast` method of `DateTimeSchema`. This is needed by the swagger-parser when constructing swagger-core models from an API document.